### PR TITLE
Correcting ungoogled-chromium to ungoogled-chromium-bin in pkglist

### DIFF
--- a/pkglist.yaml
+++ b/pkglist.yaml
@@ -20,7 +20,7 @@
     - firefox-esr-bin
     - firefox-pure
     - chromium
-    - ungoogled-chromium
+    - ungoogled-chromium-bin
     - vivaldi vivaldi-ffmpeg-codecs
     - torbrowser-launcher
     - brave-bin


### PR DESCRIPTION
Correcting package name for ungoogled chromium:
https://packages.cachyos.org/package/cachyos/x86_64/ungoogled-chromium-bin