### PR TITLE
feat(pkglist): add Hardware Tools category

### DIFF
--- a/pkglist.yaml
+++ b/pkglist.yaml
@@ -100,10 +100,13 @@
     - amdgpu_top
     - cachyos-benchmarker
     - cpu-x
+    - gparted
     - lact
+    - nvtop
     - occt
     - openlinkhub
     - openrgb
+    - rog-control-center
 
 - name: "Internet"
   packages:

--- a/pkglist.yaml
+++ b/pkglist.yaml
@@ -98,6 +98,8 @@
 - name: "Hardware Tools"
   packages:
     - amdgpu_top
+    - cachyos-benchmarker
+    - cpu-x
     - lact
     - occt
     - openlinkhub

--- a/pkglist.yaml
+++ b/pkglist.yaml
@@ -152,6 +152,11 @@
 
 - name: "Other"
   packages:
+    - openlinkhub
+    - openrgb
+
+- name: "RGB Software"
+  packages:
     - scrcpy
     - variety
 

--- a/pkglist.yaml
+++ b/pkglist.yaml
@@ -152,13 +152,13 @@
 
 - name: "Other"
   packages:
-    - openlinkhub
-    - openrgb
+    - scrcpy
+    - variety
 
 - name: "RGB Software"
   packages:
-    - scrcpy
-    - variety
+    - openlinkhub
+    - openrgb
 
 - name: "Video"
   packages:

--- a/pkglist.yaml
+++ b/pkglist.yaml
@@ -95,6 +95,14 @@
     - fontforge
     - birdfont
 
+- name: "Hardware Tools"
+  packages:
+    - amdgpu_top
+    - lact
+    - occt
+    - openlinkhub
+    - openrgb
+
 - name: "Internet"
   packages:
     - xdman
@@ -154,11 +162,6 @@
   packages:
     - scrcpy
     - variety
-
-- name: "RGB Software"
-  packages:
-    - openlinkhub
-    - openrgb
 
 - name: "Video"
   packages:


### PR DESCRIPTION
Include openrgb and openlinkhub as RGB software.
Openlinkhub is for Corsair iCUE ecosystem
https://packages.cachyos.org/package/extra/x86_64/openrgb
https://packages.cachyos.org/package/cachyos/x86_64/openlinkhub