### PR TITLE
feat(pkglist): Add winboat

### DIFF
--- a/pkglist.yaml
+++ b/pkglist.yaml
@@ -167,6 +167,7 @@
   packages:
     - scrcpy
     - variety
+    - winboat docker docker-compose"
 
 - name: "Video"
   packages:


### PR DESCRIPTION
Same as clicking the "Install Winboat" button in CachyOS Hello.

I put it in the "Other" category, because it didn't seem to fit anywhere else. MX Linux puts Wine in Misc, so I think that seems fair.